### PR TITLE
fix: getComplexValues and getDoubleComplexValues swapping RE-IMG

### DIFF
--- a/src/main/java/com/peaksolution/openatfx/api/Complex.java
+++ b/src/main/java/com/peaksolution/openatfx/api/Complex.java
@@ -19,18 +19,12 @@ public class Complex
   
   public static Complex[] getComplexValues(List<Float> values)
   {
-    Complex[] complexArray = new Complex[values.size()];
-    float r = 0;
-    for (int i = 0; i < values.size(); i++)
+    int pairCount = values.size() / 2;
+    Complex[] complexArray = new Complex[pairCount];
+    for (int i = 0; i < pairCount; i++)
     {
-      if ((i + 1) % 2 == 0)
-      {
-        r = values.get(i);
-      }
-      else
-      {
-        complexArray[(i + 1) / 2] = new Complex(r, values.get(i));
-      }
+      int valueIndex = i * 2;
+      complexArray[i] = new Complex(values.get(valueIndex), values.get(valueIndex + 1));
     }
     return complexArray;
   }

--- a/src/main/java/com/peaksolution/openatfx/api/DoubleComplex.java
+++ b/src/main/java/com/peaksolution/openatfx/api/DoubleComplex.java
@@ -19,18 +19,12 @@ public class DoubleComplex
   
   public static DoubleComplex[] getDoubleComplexValues(List<Double> values)
   {
-    DoubleComplex[] complexArray = new DoubleComplex[values.size()];
-    double r = 0;
-    for (int i = 0; i < values.size(); i++)
+    int pairCount = values.size() / 2;
+    DoubleComplex[] complexArray = new DoubleComplex[pairCount];
+    for (int i = 0; i < pairCount; i++)
     {
-      if ((i + 1) % 2 == 0)
-      {
-        r = values.get(i);
-      }
-      else
-      {
-        complexArray[(i + 1) / 2] = new DoubleComplex(r, values.get(i));
-      }
+      int valueIndex = i * 2;
+      complexArray[i] = new DoubleComplex(values.get(valueIndex), values.get(valueIndex + 1));
     }
     return complexArray;
   }

--- a/src/test/java/com/peaksolution/openatfx/ExtCompWriterRoundtripTest.java
+++ b/src/test/java/com/peaksolution/openatfx/ExtCompWriterRoundtripTest.java
@@ -1,0 +1,206 @@
+package com.peaksolution.openatfx;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.asam.ods.AoFactory;
+import org.asam.ods.AoSession;
+import org.asam.ods.ApplicationAttribute;
+import org.asam.ods.ApplicationElement;
+import org.asam.ods.ApplicationStructure;
+import org.asam.ods.InstanceElement;
+import org.asam.ods.InstanceElementIterator;
+import org.asam.ods.SetType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.omg.CORBA.ORB;
+
+import com.peaksolution.openatfx.api.BaseRelation;
+import com.peaksolution.openatfx.api.Complex;
+import com.peaksolution.openatfx.api.DoubleComplex;
+import com.peaksolution.openatfx.api.Element;
+import com.peaksolution.openatfx.api.Instance;
+import com.peaksolution.openatfx.api.NameValueUnit;
+import com.peaksolution.openatfx.api.OpenAtfxAPI;
+import com.peaksolution.openatfx.api.OpenAtfxException;
+import com.peaksolution.openatfx.api.Relation;
+
+@ExtendWith(GlassfishCorbaExtension.class)
+class ExtCompWriterRoundtripTest {
+
+    @Test
+    void testComplexAndDComplexRoundtrip(@TempDir Path tempDir) throws OpenAtfxException {
+        Path atfxFile = tempDir.resolve("complex_roundtrip.atfx");
+        OpenAtfx openAtfx = new OpenAtfx();
+        OpenAtfxAPI api = openAtfx.createNewFile(atfxFile, 36);
+
+        ensureUnitInfrastructure(api);
+
+        // Build minimal model with local columns and external component relation for binary value storage.
+        Element mqElement = api.createElement("AoMeasurementQuantity", "MeaQuantity");
+        Element lcElement = api.createElement("AoLocalColumn", "LocalColumn");
+        Element ecElement = api.createElement("AoExternalComponent", "ExternalComponent");
+        com.peaksolution.openatfx.api.Attribute globalFlagAttribute = api.createAttribute(lcElement.getId(),
+            "GlobalFlag", "global_flag", com.peaksolution.openatfx.api.DataType.DT_SHORT, 1, 0, null, false,
+            false, false);
+
+        BaseRelation lcMqBaseRel = api.getBaseRelation("aolocalcolumn", "aomeasurementquantity");
+        Relation lcMqRel = api.createRelation(lcElement, mqElement, lcMqBaseRel, "MeasurementQuantity", "LocalColumns",
+                (short) 1, (short) 1);
+
+        BaseRelation ecLcBaseRel = api.getBaseRelation("AoExternalComponent", "AoLocalColumn");
+        Relation ecLcRel = api.createRelation(ecElement, lcElement, ecLcBaseRel, "LocalColumn", "ExternalComponents",
+                (short) 1, (short) 1);
+
+        Instance mqComplex = createMq(api, mqElement, com.peaksolution.openatfx.api.DataType.DT_COMPLEX.ordinal(),
+            "MqComplex");
+        Instance mqDComplex = createMq(api, mqElement, com.peaksolution.openatfx.api.DataType.DT_DCOMPLEX.ordinal(),
+            "MqDComplex");
+
+        Complex[] complexExpected = new Complex[] {
+                new Complex(1.1f, 0.1f),
+                new Complex(-2.2f, 3.3f),
+                new Complex(Float.MIN_VALUE, Float.MAX_VALUE)
+        };
+        DoubleComplex[] dcomplexExpected = new DoubleComplex[] {
+                new DoubleComplex(1.11, 0.11),
+                new DoubleComplex(-2.22, 3.33),
+                new DoubleComplex(Double.MIN_VALUE, Double.MAX_VALUE)
+        };
+
+        Instance lcComplex = createLc(api, lcElement, globalFlagAttribute.getName(), "LC_COMPLEX",
+            com.peaksolution.openatfx.api.DataType.DS_COMPLEX, complexExpected);
+        Instance lcDComplex = createLc(api, lcElement, globalFlagAttribute.getName(), "LC_DCOMPLEX",
+            com.peaksolution.openatfx.api.DataType.DS_DCOMPLEX, dcomplexExpected);
+
+        api.setRelatedInstances(lcElement.getId(), lcComplex.getIid(), lcMqRel.getRelationName(),
+                Arrays.asList(mqComplex.getIid()), SetType.UPDATE);
+        api.setRelatedInstances(lcElement.getId(), lcDComplex.getIid(), lcMqRel.getRelationName(),
+                Arrays.asList(mqDComplex.getIid()), SetType.UPDATE);
+
+        Instance ecComplex = createEc(api, ecElement, "EC_COMPLEX");
+        Instance ecDComplex = createEc(api, ecElement, "EC_DCOMPLEX");
+
+        api.setRelatedInstances(ecElement.getId(), ecComplex.getIid(), ecLcRel.getRelationName(),
+                Arrays.asList(lcComplex.getIid()), SetType.UPDATE);
+        api.setRelatedInstances(ecElement.getId(), ecDComplex.getIid(), ecLcRel.getRelationName(),
+                Arrays.asList(lcDComplex.getIid()), SetType.UPDATE);
+
+        api.writeAtfx(atfxFile.toFile());
+
+        try {
+            ORB orb = ORB.init(new String[0], System.getProperties());
+            AoFactory factory = AoServiceFactory.getInstance().newAoFactory(orb);
+            AoSession session = factory.newSession("FILENAME=" + atfxFile.toFile());
+            try {
+                ApplicationStructure as = session.getApplicationStructure();
+                ApplicationElement lcApplicationElement = as.getElementsByBaseType("AoLocalColumn")[0];
+                ApplicationAttribute valuesAttribute = lcApplicationElement.getAttributeByBaseName("values");
+
+                boolean foundComplex = false;
+                boolean foundDComplex = false;
+
+                InstanceElementIterator lcIterator = lcApplicationElement.getInstances("*");
+                for (int i = 0; i < lcIterator.getCount(); i++) {
+                    InstanceElement localColumn = lcIterator.nextOne();
+                    String lcName = localColumn.getValueByBaseName("name").value.u.stringVal();
+                    org.asam.ods.NameValueUnit values = localColumn.getValue(valuesAttribute.getName());
+
+                    if ("LC_COMPLEX".equals(lcName)) {
+                        foundComplex = true;
+                        assertArrayEquals(toScalarArray(complexExpected), toScalarArray(values.value.u.complexSeq()),
+                                0.00001f);
+                    } else if ("LC_DCOMPLEX".equals(lcName)) {
+                        foundDComplex = true;
+                        assertArrayEquals(toScalarArray(dcomplexExpected), toScalarArray(values.value.u.dcomplexSeq()),
+                                0.000000000001d);
+                    }
+                }
+
+                assertTrue(foundComplex, "Complex local column should be found and readable");
+                assertTrue(foundDComplex, "DComplex local column should be found and readable");
+            } finally {
+                session.close();
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Roundtrip validation failed", e);
+        }
+    }
+
+    private void ensureUnitInfrastructure(OpenAtfxAPI api) throws OpenAtfxException {
+        if (api.getElementsByBaseType("AoUnit").isEmpty()) {
+            Element dimElement = api.createElement("AoPhysicalDimension", "PhysDim");
+            Element unitElement = api.createElement("AoUnit", "Unit");
+            api.createRelationFromBaseRelation(unitElement.getId(), dimElement.getId(), "phys_dimension", "dim",
+                    "units");
+        }
+    }
+
+    private Instance createMq(OpenAtfxAPI api, Element mqElement, int dataTypeOrdinal, String name)
+            throws OpenAtfxException {
+        Collection<NameValueUnit> values = new ArrayList<>();
+        values.add(new NameValueUnit("name", com.peaksolution.openatfx.api.DataType.DT_STRING, name));
+        values.add(new NameValueUnit(mqElement.getAttributeByBaseName("datatype").getName(),
+                com.peaksolution.openatfx.api.DataType.DT_ENUM, dataTypeOrdinal));
+        return api.createInstance(mqElement.getId(), values);
+    }
+
+    private Instance createLc(OpenAtfxAPI api, Element lcElement, String globalFlagAttributeName, String name,
+            com.peaksolution.openatfx.api.DataType dsType, Object value) throws OpenAtfxException {
+        Collection<NameValueUnit> values = new ArrayList<>();
+        values.add(new NameValueUnit("name", com.peaksolution.openatfx.api.DataType.DT_STRING, name));
+        values.add(new NameValueUnit(globalFlagAttributeName, com.peaksolution.openatfx.api.DataType.DT_SHORT,
+                (short) 15));
+        values.add(new NameValueUnit(lcElement.getAttributeByBaseName("values").getName(), dsType, value));
+        return api.createInstance(lcElement.getId(), values);
+    }
+
+    private Instance createEc(OpenAtfxAPI api, Element ecElement, String name) throws OpenAtfxException {
+        Collection<NameValueUnit> values = new ArrayList<>();
+        values.add(new NameValueUnit(ecElement.getAttributeByBaseName("name").getName(),
+                com.peaksolution.openatfx.api.DataType.DT_STRING, name));
+        return api.createInstance(ecElement.getId(), values);
+    }
+
+    private float[] toScalarArray(Complex[] values) {
+        float[] result = new float[values.length * 2];
+        for (int i = 0; i < values.length; i++) {
+            result[i * 2] = values[i].getR();
+            result[i * 2 + 1] = values[i].getI();
+        }
+        return result;
+    }
+
+    private float[] toScalarArray(org.asam.ods.T_COMPLEX[] values) {
+        float[] result = new float[values.length * 2];
+        for (int i = 0; i < values.length; i++) {
+            result[i * 2] = values[i].r;
+            result[i * 2 + 1] = values[i].i;
+        }
+        return result;
+    }
+
+    private double[] toScalarArray(DoubleComplex[] values) {
+        double[] result = new double[values.length * 2];
+        for (int i = 0; i < values.length; i++) {
+            result[i * 2] = values[i].getR();
+            result[i * 2 + 1] = values[i].getI();
+        }
+        return result;
+    }
+
+    private double[] toScalarArray(org.asam.ods.T_DCOMPLEX[] values) {
+        double[] result = new double[values.length * 2];
+        for (int i = 0; i < values.length; i++) {
+            result[i * 2] = values[i].r;
+            result[i * 2 + 1] = values[i].i;
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/peaksolution/openatfx/api/ComplexConversionTest.java
+++ b/src/test/java/com/peaksolution/openatfx/api/ComplexConversionTest.java
@@ -1,0 +1,123 @@
+package com.peaksolution.openatfx.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ComplexConversionTest {
+
+    private static List<Float> toScalarList(Complex[] values) {
+        List<Float> result = new ArrayList<>();
+        for (Complex value : values) {
+            result.add(value.getR());
+            result.add(value.getI());
+        }
+        return result;
+    }
+
+    private static List<Double> toScalarList(DoubleComplex[] values) {
+        List<Double> result = new ArrayList<>();
+        for (DoubleComplex value : values) {
+            result.add(value.getR());
+            result.add(value.getI());
+        }
+        return result;
+    }
+
+    @Test
+    void testGetComplexValuesRealImaginaryOrderAndLength() {
+        Complex[] complex = Complex.getComplexValues(
+                Arrays.asList(1.1f, 0.1f, -2.2f, 3.3f, Float.MIN_VALUE, Float.MAX_VALUE));
+
+        assertEquals(3, complex.length);
+        assertEquals(1.1f, complex[0].getR());
+        assertEquals(0.1f, complex[0].getI());
+        assertEquals(-2.2f, complex[1].getR());
+        assertEquals(3.3f, complex[1].getI());
+        assertEquals(Float.MIN_VALUE, complex[2].getR());
+        assertEquals(Float.MAX_VALUE, complex[2].getI());
+    }
+
+    @Test
+    void testGetComplexValuesOddLengthIgnoresTrailingScalar() {
+        Complex[] complex = Complex.getComplexValues(Arrays.asList(10f, 20f, 99f));
+
+        assertEquals(1, complex.length);
+        assertEquals(10f, complex[0].getR());
+        assertEquals(20f, complex[0].getI());
+    }
+
+    @Test
+    void testGetComplexValuesEmptyInput() {
+        Complex[] complex = Complex.getComplexValues(Collections.emptyList());
+
+        assertEquals(0, complex.length);
+    }
+
+    @Test
+    void testComplexRoundtripPreservesOrderAndValues() {
+        Complex[] original = new Complex[] {
+                new Complex(1.25f, -2.5f),
+                new Complex(0f, 3f),
+                new Complex(Float.MIN_VALUE, Float.MAX_VALUE)
+        };
+
+        Complex[] roundtrip = Complex.getComplexValues(toScalarList(original));
+
+        assertEquals(original.length, roundtrip.length);
+        for (int i = 0; i < original.length; i++) {
+            assertEquals(original[i], roundtrip[i]);
+        }
+    }
+
+    @Test
+    void testGetDoubleComplexValuesRealImaginaryOrderAndLength() {
+        DoubleComplex[] complex = DoubleComplex
+                .getDoubleComplexValues(Arrays.asList(1.11, 0.11, -2.22, 3.33, Double.MIN_VALUE, Double.MAX_VALUE));
+
+        assertEquals(3, complex.length);
+        assertEquals(1.11, complex[0].getR());
+        assertEquals(0.11, complex[0].getI());
+        assertEquals(-2.22, complex[1].getR());
+        assertEquals(3.33, complex[1].getI());
+        assertEquals(Double.MIN_VALUE, complex[2].getR());
+        assertEquals(Double.MAX_VALUE, complex[2].getI());
+    }
+
+    @Test
+    void testGetDoubleComplexValuesOddLengthIgnoresTrailingScalar() {
+        DoubleComplex[] complex = DoubleComplex.getDoubleComplexValues(Arrays.asList(10d, 20d, 99d));
+
+        assertEquals(1, complex.length);
+        assertEquals(10d, complex[0].getR());
+        assertEquals(20d, complex[0].getI());
+    }
+
+    @Test
+    void testGetDoubleComplexValuesEmptyInput() {
+        DoubleComplex[] complex = DoubleComplex.getDoubleComplexValues(Collections.emptyList());
+
+        assertEquals(0, complex.length);
+    }
+
+    @Test
+    void testDoubleComplexRoundtripPreservesOrderAndValues() {
+        DoubleComplex[] original = new DoubleComplex[] {
+                new DoubleComplex(1.125, -2.25),
+                new DoubleComplex(0d, 3d),
+                new DoubleComplex(Double.MIN_VALUE, Double.MAX_VALUE)
+        };
+
+        DoubleComplex[] roundtrip = DoubleComplex.getDoubleComplexValues(toScalarList(original));
+
+        assertEquals(original.length, roundtrip.length);
+        for (int i = 0; i < original.length; i++) {
+            assertEquals(original[i], roundtrip[i]);
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors the logic for converting lists of scalars to arrays of `Complex` and `DoubleComplex` objects, and adds comprehensive unit and integration tests to ensure correctness. The changes simplify the conversion methods, ensure consistent behavior (such as ignoring trailing scalars for odd-length lists), and provide robust test coverage for both typical and edge cases.

### Refactoring and Logic Simplification

* Refactored `Complex.getComplexValues(List<Float>)` and `DoubleComplex.getDoubleComplexValues(List<Double>)` to pair scalars as real and imaginary parts, creating arrays of complex numbers. The new implementation ignores any trailing scalar if the input list has an odd length, ensuring only complete pairs are converted. [[1]](diffhunk://#diff-f2e80bf9e3c107ebda06f0ac620bfced2fda1b0ffb476ed1a3554946cb20e7c9L22-R27) [[2]](diffhunk://#diff-c8f278f92e67519be077a9abdaebe7e7208cef501d7b02e76cead8680bfee0ffL22-R27)

### Testing Improvements

* Added `ComplexConversionTest.java` with unit tests covering correct pairing, handling of odd-length and empty lists, and roundtrip conversions for both `Complex` and `DoubleComplex` types.
* Added `ExtCompWriterRoundtripTest.java`, an integration test that verifies end-to-end reading and writing of complex and double complex values in ATFX files, ensuring data integrity through the full persistence cycle.